### PR TITLE
iam-account: add service account IAM members

### DIFF
--- a/examples/iam-account/single/README.md
+++ b/examples/iam-account/single/README.md
@@ -22,7 +22,9 @@ terraform apply
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_yandex"></a> [yandex](#provider\_yandex) | >= 0.72.0 |
 
 ## Modules
 
@@ -32,7 +34,11 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [yandex_iam_service_account.sa_user](https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs/resources/iam_service_account) | resource |
+| [yandex_lockbox_secret.sa_static_key](https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs/resources/lockbox_secret) | resource |
+| [yandex_client_config.client](https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs
 

--- a/examples/iam-account/single/main.tf
+++ b/examples/iam-account/single/main.tf
@@ -1,7 +1,26 @@
+data "yandex_client_config" "client" {}
+
+locals {
+  sa_name = "test-iam-accounts"
+}
+
+# Сервисный аккаунт, которому выдана роль на основном (запуск ресурсов от его имени, ключи, impersonate).
+resource "yandex_iam_service_account" "sa_user" {
+  name        = "${local.sa_name}-user"
+  description = "Сервисный аккаунт с правом использовать основной SA"
+  folder_id   = data.yandex_client_config.client.folder_id
+}
+
+resource "yandex_lockbox_secret" "sa_static_key" {
+  name        = "sa-static-access-key-${local.sa_name}"
+  description = "Static access key for service account"
+  folder_id   = data.yandex_client_config.client.folder_id
+}
+
 module "iam_accounts" {
   source = "../../../modules/iam-account"
 
-  name = "test-iam-accounts"
+  name = local.sa_name
   folder_roles = [
     "editor",
     "container-registry.images.puller",
@@ -12,16 +31,22 @@ module "iam_accounts" {
   enable_api_key           = false
   enable_account_key       = false
 
-  # Новые параметры для интеграции с Lockbox
-  # static_access_key_output_to_lockbox = {
-  #   secret_id = "e4q2b8a3b1c2d3e4f5g6h7i8j9k0l1m"
-  #   key       = "static_access_key"
-  # }
+  # Кто может использовать этот сервисный аккаунт (запуск ресурсов от его имени, ключи, impersonate).
+  service_account_iam_members = [
+    {
+      role   = "iam.serviceAccounts.user"
+      member = "serviceAccount:${yandex_iam_service_account.sa_user.id}"
+    }
+  ]
+
+  static_access_key_output_to_lockbox = {
+    secret_id = yandex_lockbox_secret.sa_static_key.id
+    key       = "static_access_key"
+  }
 
   timeouts = {
     create = "30m"
     update = "30m"
     delete = "30m"
   }
-
 }

--- a/modules/iam-account/README.md
+++ b/modules/iam-account/README.md
@@ -35,6 +35,7 @@ No modules.
 |------|------|
 | [yandex_iam_service_account.main](https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs/resources/iam_service_account) | resource |
 | [yandex_iam_service_account_api_key.main](https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs/resources/iam_service_account_api_key) | resource |
+| [yandex_iam_service_account_iam_member.main](https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs/resources/iam_service_account_iam_member) | resource |
 | [yandex_iam_service_account_key.main](https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs/resources/iam_service_account_key) | resource |
 | [yandex_iam_service_account_static_access_key.main](https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs/resources/iam_service_account_static_access_key) | resource |
 | [yandex_resourcemanager_cloud_iam_member.main](https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs/resources/resourcemanager_cloud_iam_member) | resource |
@@ -60,6 +61,7 @@ No modules.
 | <a name="input_folder_id"></a> [folder\_id](#input\_folder\_id) | Folder-ID where need to add permissions. If omitted default FOLDER\_ID will be used | `string` | `null` | no |
 | <a name="input_folder_roles"></a> [folder\_roles](#input\_folder\_roles) | A list of roles that will be attached to in folder scope | `list(string)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | Service account name | `string` | n/a | yes |
+| <a name="input_service_account_iam_members"></a> [service\_account\_iam\_members](#input\_service\_account\_iam\_members) | List of { role, member } to grant roles on this service account (e.g. iam.serviceAccounts.user). Member format: userAccount:id, serviceAccount:id, federatedUser:id, system:group:id | <pre>list(object({<br/>    role   = string<br/>    member = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_static_access_key_output_to_lockbox"></a> [static\_access\_key\_output\_to\_lockbox](#input\_static\_access\_key\_output\_to\_lockbox) | Configuration for storing static access key in Yandex Lockbox secret | <pre>object({<br/>    secret_id = string<br/>    key       = string<br/>  })</pre> | `null` | no |
 | <a name="input_static_access_key_pgp_key"></a> [static\_access\_key\_pgp\_key](#input\_static\_access\_key\_pgp\_key) | An optional PGP key to encrypt the resulting private key material | `string` | `null` | no |
 | <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Timeout settings for cluster operations | <pre>object({<br/>    create = optional(string)<br/>    update = optional(string)<br/>    delete = optional(string)<br/>  })</pre> | `null` | no |

--- a/modules/iam-account/main.tf
+++ b/modules/iam-account/main.tf
@@ -8,7 +8,7 @@ locals {
 resource "yandex_iam_service_account" "main" {
   name        = var.name
   description = var.description
-  folder_id   = var.folder_id
+  folder_id   = local.folder_id
 
   dynamic "timeouts" {
     for_each = var.timeouts == null ? [] : [var.timeouts]
@@ -39,4 +39,15 @@ resource "yandex_resourcemanager_cloud_iam_member" "main" {
   member   = "serviceAccount:${yandex_iam_service_account.main.id}"
   role     = each.value
 
+}
+
+# Роли на самом сервисном аккаунте (кто может им пользоваться, например iam.serviceAccounts.user)
+resource "yandex_iam_service_account_iam_member" "main" {
+  for_each = length(var.service_account_iam_members) > 0 ? {
+    for idx, m in var.service_account_iam_members : "${idx}-${m.member}-${m.role}" => m
+  } : {}
+
+  service_account_id = yandex_iam_service_account.main.id
+  role               = each.value.role
+  member             = each.value.member
 }

--- a/modules/iam-account/variables.tf
+++ b/modules/iam-account/variables.tf
@@ -42,6 +42,18 @@ variable "cloud_roles" {
 }
 
 #
+# IAM members on the service account (who can use this SA)
+#
+variable "service_account_iam_members" {
+  description = "List of { role, member } to grant roles on this service account (e.g. iam.serviceAccounts.user). Member format: userAccount:id, serviceAccount:id, federatedUser:id, system:group:id"
+  type = list(object({
+    role   = string
+    member = string
+  }))
+  default = []
+}
+
+#
 # keys options
 #
 variable "enable_static_access_key" {


### PR DESCRIPTION
- Модуль iam-account: добавлена возможность выдавать роли на создаваемый сервисный аккаунт (кто может им пользоваться). Реализовано через переменную service_account_iam_members (список { role, member }) и ресурс yandex_iam_service_account_iam_member. Типичный случай — роль iam.serviceAccounts.user.
- Пример examples/iam-account/single: добавлено использование service_account_iam_members. В конфиге создаётся второй сервисный аккаунт, которому выдаётся право использовать основной (запуск ресурсов от его имени, ключи, impersonate). 
